### PR TITLE
updated csv export with converters for long ints and birthdates

### DIFF
--- a/ValidationWeb/Services/Implementations/DynamicReportingService.cs
+++ b/ValidationWeb/Services/Implementations/DynamicReportingService.cs
@@ -100,7 +100,6 @@ namespace ValidationWeb.Services.Implementations
                 queryCommand.CommandText = $"SELECT {fieldNames} FROM {viewName}";
 
                 if (!reportDefinition.IsOrgLevelReport || districtId.HasValue)
-                // && selectedFields.Any(x => x.Field.Name.Equals("DistrictId", StringComparison.InvariantCultureIgnoreCase)))
                 {
                     queryCommand.CommandText += $" where [DistrictId] = {districtId}";
                 }
@@ -115,7 +114,7 @@ namespace ValidationWeb.Services.Implementations
                         foreach (var field in selectedFields)
                         {
                             var fieldDescription = !string.IsNullOrWhiteSpace(field.Description) ? field.Description : field.Field.Name;
-                            dynamicObject.Add(fieldDescription, reader[field.Field.Name].ToString());
+                            dynamicObject.Add(fieldDescription, reader[field.Field.Name]);
                         }
 
                         report.Add(dynamicObject);

--- a/ValidationWeb/Utility/Utility.cs
+++ b/ValidationWeb/Utility/Utility.cs
@@ -1,13 +1,16 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Configuration.Internal;
 using System.Globalization;
 using System.IO;
-using System.Web.UI;
 
 using CsvHelper;
+using CsvHelper.Configuration;
+using CsvHelper.TypeConversion;
 
 namespace ValidationWeb.Utility
 {
-    public class Csv
+    public static class Csv
     {
         public static byte[] WriteCsvToMemory<T>(IEnumerable<T> records)
         {
@@ -16,9 +19,71 @@ namespace ValidationWeb.Utility
 
             using (var csvWriter = new CsvWriter(streamWriter, CultureInfo.CurrentCulture))
             {
+                csvWriter.Configuration.TypeConverterCache.AddConverter<DateTime>(new MidnightDateTimeConverter());
+                csvWriter.Configuration.TypeConverterCache.AddConverter<DateTime?>(new MidnightDateTimeConverter());
+                csvWriter.Configuration.TypeConverterCache.AddConverter<string>(new LongNumericStringValueConverter());
+                csvWriter.Configuration.TypeConverterCache.AddConverter<int>(new LongIntegerToStringConverter());
                 csvWriter.WriteRecords(records);
                 streamWriter.Flush();
                 return memoryStream.ToArray();
+            }
+        }
+
+        private class LongNumericStringValueConverter : StringConverter
+        {
+            public override string ConvertToString(object value, IWriterRow row, MemberMapData memberMapData)
+            {
+                var stringValue = value as string;
+
+                if (stringValue == null)
+                {
+                    return null;
+                }
+
+                int n;
+                if (stringValue.Length >= 9 && int.TryParse(stringValue, out n))
+                {
+                    return $"=\"{base.ConvertToString(value, row, memberMapData)}\"";
+                }
+
+                return base.ConvertToString(value, row, memberMapData);
+            }
+        }
+
+        private class LongIntegerToStringConverter : Int32Converter
+        {
+            public override string ConvertToString(object value, IWriterRow row, MemberMapData memberMapData)
+            {
+                if (value == null)
+                {
+                    return null;
+                }
+
+                var intValue = (int)value;
+                var stringValue = intValue.ToString();
+                if (stringValue.Length >= 9)
+                {
+                    return $"=\"{stringValue}\"";
+                }
+
+                return base.ConvertToString(value, row, memberMapData);
+            }
+        }
+
+        private class MidnightDateTimeConverter : DateTimeConverter
+        {
+            public override string ConvertToString(object value, IWriterRow row, MemberMapData memberMapData)
+            {
+                if (value == null)
+                {
+                    return base.ConvertToString(value, row, memberMapData);
+                }
+
+                var date = (DateTime)value;
+
+                return (int)date.TimeOfDay.TotalSeconds == 0 ? 
+                           date.ToString("MM/dd/yyyy") : 
+                           base.ConvertToString(value, row, memberMapData);
             }
         }
     }


### PR DESCRIPTION
numeric strings >= 9 chars, and ints that would be >= 9 chars in strings, are exported as "=""xxx""" so excel treats them as string values (="xxx")

birthdates were showing up as 1/1/1980 12:00:00 AM, fixed to just print MM/dd/yyyy in excel