### PR TITLE
Fixed syntax errors related to Rule ID support and duplicate rules 

### DIFF
--- a/Engine/Language/MsdsLexer.g4
+++ b/Engine/Language/MsdsLexer.g4
@@ -54,8 +54,9 @@ COMMA : ',';
 DOT : '.';
 NEG : '-';
 
-RULEID1 : INT DOT INT;              // 100.1
-RULEID2 : INT DOT INT DOT INT;      // 100.1.2
+RULEID1 : INT DOT INT;                       // 100.1
+RULEID2 : INT DOT INT DOT INT;              // 100.1.2
+RULEID3 : INT DOT INT DOT INT DOT INT;     // 100.1.2.3
 
 fragment DIGIT : [0-9] ;
 INT :   DIGIT+ ;

--- a/Engine/Language/MsdsParser.g4
+++ b/Engine/Language/MsdsParser.g4
@@ -35,7 +35,7 @@ ruleDefinition
             ELSE error
     ;
 
-ruleid : RULEID1 | RULEID2;
+ruleid : RULEID1 | RULEID2 | RULEID3;
 
 error : STRING;
 

--- a/Engine/Models/Collection.cs
+++ b/Engine/Models/Collection.cs
@@ -21,23 +21,27 @@ namespace Engine.Models
 
         public Collection(string collectionId)
         {
-            this.CollectionId = collectionId;
+            CollectionId = collectionId;
         }
 
         public void AddRulesetReference(string rulesetId)
         {
             if (string.IsNullOrEmpty(rulesetId) || _rulesetIds.Contains(rulesetId))
+            {
                 throw new ArgumentException($"Duplicate or null RulesetId: {rulesetId}", nameof(rulesetId));
-            else
-                _rulesetIds.Add(rulesetId);
+            }
+            
+            _rulesetIds.Add(rulesetId);
         }
 
         public void AddRuleReference(string ruleId)
         {
             if (string.IsNullOrEmpty(ruleId) || _ruleIds.Contains(ruleId))
+            {
                 throw new ArgumentException($"Duplicate RuleId: {ruleId}", nameof(ruleId));
-            else
-                _ruleIds.Add(ruleId);
+            }
+
+            _ruleIds.Add(ruleId);
         }
     }
 }

--- a/Engine/Models/Model.cs
+++ b/Engine/Models/Model.cs
@@ -45,8 +45,12 @@ namespace Engine.Models
 
         public void AddRule(Rule rule)
         {
-            if (string.IsNullOrEmpty(rule.RuleId) || _rules.Any(x => x.RuleId == rule.RuleId))
+            if (string.IsNullOrEmpty(rule.RuleId) || 
+                _rules.Any(x => x.RuleId == rule.RuleId && x.RulesetId == rule.RulesetId))
+            {
                 throw new ArgumentException($"Duplicate RuleId: {rule.RuleId}", nameof(rule));
+            }
+
             _rules.Add(rule);
         }
 

--- a/Engine/Templates/RuleDefinition.hbs
+++ b/Engine/Templates/RuleDefinition.hbs
@@ -1,5 +1,13 @@
-﻿SELECT DISTINCT [Ids].[Id], [Ids].[DistrictId], [Ids].[DistrictIdLeft], [Ids].[DistrictIdRight], '{{{ruleid}}}' [RuleId], CAST({{{#if iserror}}}1{{{else}}}0{{{/if}}} AS BIT) [IsError], {{{message}}} [Message]
+﻿SELECT DISTINCT [Ids].[Id], [Ids].[DistrictId], [Ids].[DistrictIdLeft], [Ids].[DistrictIdRight],
+'{{{ruleid}}}'
+[RuleId],
+CAST({{{#if iserror}}}1{{{else}}}0{{{/if}}} AS BIT) [IsError], {{{message}}} [Message]
 FROM ({{{#each tables}}}{{{#unless @first}}} UNION {{{/unless}}}SELECT [Id], [DistrictId], [DistrictIdLeft], [DistrictIdRight] FROM [{{{../schema}}}].[{{{this}}}]{{{/each}}}) [Ids]
-{{{#each tables}}}LEFT OUTER JOIN [{{{../schema}}}].[{{{this}}}] ON [Ids].[Id] = [{{{this}}}].[Id] {{{/each}}}
+{{{#each tables}}}
+      LEFT OUTER JOIN [{{{../schema}}}].[{{{this}}}] ON [Ids].[Id] = [{{{this}}}].[Id]
+  {{{#if @first}}}
+      AND [Ids].[DistrictId] = [{{{this}}}{{{../tableSuffix}}}].[DistrictId]
+  {{{/if}}}
+{{{/each}}}
 {{{#if sqlFilters}}}WHERE ({{{sqlFilters}}}){{{#if sqlConditions}}} AND NOT ({{{sqlConditions}}}){{{/if}}}
 {{{else}}}{{{#if sqlConditions}}}WHERE NOT ({{{sqlConditions}}}){{{/if}}}{{{/if}}}

--- a/ValidationWeb/Content/Rules/EarlyEdEnrollmentStudentRuleSet.rules
+++ b/ValidationWeb/Content/Rules/EarlyEdEnrollmentStudentRuleSet.rules
@@ -115,13 +115,13 @@ rule 52.10.6386
 	require that {StudentEnrollmentEE}.[DistrictType] <> '7' 
 	else '288. Student has resident district number 0001 and type of 01 (Aitkin) which is an invalid resident district number and type for charter school.'
 
-rule 52.10.6436 
+rule 52.10.6436
 	when {StudentEnrollmentEE}.[GradeLevel] = 'EE' then
 	require that {StudentEnrollmentEE}.[SchoolClassification] is not in ['41','42','43','45','50','51']
 	else '395. Grades EE cannot be reported in school classifications 41, 42, 43, 45, 50 or 51. Check student grade level and school'
 	
-rule 52.10.6436.1 
-	when {StudentEnrollmentEE}.[SchoolClassification] is in ['84','85'] 
+rule 52.10.6436.1
+	when {StudentEnrollmentEE}.[SchoolClassification] is in ['84','85'] then
 	require that {StudentEnrollmentEE}.[GradeLevel] = 'EE'
 	else 'Student who is not in gradelevel EE is enrolled in a school with school classification of 84 or 85. Only EE gradelevels can be reported with classification 84 or 85.'
 	

--- a/ValidationWeb/Content/Rules/StudentEnrollment.rules
+++ b/ValidationWeb/Content/Rules/StudentEnrollment.rules
@@ -1119,8 +1119,8 @@ rule 10.10.6593
 	else '243. If the school is not an ALC/ALP school (classifications 41, 42, or 43), OR the homebound indicator= Y, the Independent Study flag must be N.  Check the school classification.'
 	
 	
-rule 52.10.6436.1 
-	when {StudentEnrollment}.[SchoolClassification] is in ['84','85'] 
+rule 52.10.6436.1
+	when {StudentEnrollment}.[SchoolClassification] is in ['84','85'] then
 	require that {StudentEnrollment}.[StudentGradeLevel] = 'EE'
 	else 'Student who is not in gradelevel EE is enrolled in a school with school classification of 84 or 85. Only EE gradelevels can be reported with classification 84 or 85.'
 	


### PR DESCRIPTION
**MOAI-264**
Added a clause to emitted SQL queries to tie error district to enrolled district

**MOAI-298:**
Error spam eliminated, rules left intact. 

The rules engine had only supported 3-part rule ID's, e.g. 52.10.6436. our syntax errors were simply because 4-part id's like 52.10.6436.1 were not supported by the language parser. I added the four-part format to the lex parser thing so it will recognize those as valid rule IDs. So this has been fixed and those rules will load and run now. 

Additionally, we were disallowing duplicate rule id's across collections. I confirmed that the engine stores these per-collection and uniqueness of rule id's is only required within a collection. I improved the guard code around this so it will only log errors if there are duplicates within a collection. 